### PR TITLE
SB 110335648 more shared config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,14 @@ var config = {
   })]
 };
 
+if (!isDevelopment) {
+  config.plugins.push(new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify('production')
+    }
+  }));
+}
+
 /** Add images to build **/
 var images = glob.sync('app/assets/images/**/*.+(jpg|jpeg|gif|png|ico)');
 images.forEach(function (image) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ var config = {
     root: nodeModulesDir
   },
   amd: { jQuery: true },
-  plugins: [new WebpackMd5HashPlugin(), new webpack.optimize.OccurenceOrderPlugin(), new webpack.NoErrorsPlugin(), new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/), new ExtractTextPlugin(cssFilename(), { allChunks: true }), new AssetManifestPlugin('public/assets/webpack-assets.json', path.resolve(cwd, 'app/assets/images')), new AssetsPlugin({
+  plugins: [new WebpackMd5HashPlugin(), new webpack.optimize.OccurenceOrderPlugin(), new webpack.NoErrorsPlugin(), new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/), new ExtractTextPlugin(cssFilename(), { allChunks: true }), new AssetManifestPlugin('public/assets/webpack-assets.json', imageDir), new AssetsPlugin({
     path: path.join(cwd, 'public', 'assets'),
     filename: 'webpack-bundles.json'
   })]

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,14 @@ const config = {
   ]
 }
 
+if (!isDevelopment) {
+  config.plugins.push(new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify('production')
+    }
+  }))
+}
+
 /** Add images to build **/
 const images = glob.sync('app/assets/images/**/*.+(jpg|jpeg|gif|png|ico)')
 images.forEach(image => {

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const appEnv = process.env.APPLICATION_ENVIRONMENT || 'production'
 const isDevelopment = appEnv == 'development'
 
 const jsFilename = function() {
-  if(isDevelopment) {
+  if (isDevelopment) {
     return "[name]-bundle.js"
   } else {
     return "[name]-bundle-[chunkhash].js"
@@ -26,7 +26,7 @@ const jsFilename = function() {
 }
 
 const cssFilename = function() {
-  if(isDevelopment) {
+  if (isDevelopment) {
     return "[name]-bundle.css"
   } else {
     return "[name]-bundle-[chunkhash].css"
@@ -37,7 +37,7 @@ const imageLoader = function() {
   const result = {
     test: /.*\.(gif|png|jpe?g|svg|ico)$/i,
   }
-  if(isDevelopment) {
+  if (isDevelopment) {
     result.loader = "file?name=[name].[ext]"
   } else {
     result.loaders = [
@@ -50,7 +50,7 @@ const imageLoader = function() {
 
 const aliasConfig = function() {
   const aliasConfigFile = path.resolve(cwd, 'webpack-alias.config.js')
-  if(fs.existsSync(aliasConfigFile)) {
+  if (fs.existsSync(aliasConfigFile)) {
     return require(aliasConfigFile)
   } else {
     return {}
@@ -103,7 +103,7 @@ const config = {
     new webpack.NoErrorsPlugin(),
     new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
     new ExtractTextPlugin(cssFilename(), { allChunks: true }),
-    new AssetManifestPlugin('public/assets/webpack-assets.json', path.resolve(cwd, 'app/assets/images')),
+    new AssetManifestPlugin('public/assets/webpack-assets.json', imageDir),
     new AssetsPlugin({
       path: path.join(cwd, 'public', 'assets'),
       filename: 'webpack-bundles.json'


### PR DESCRIPTION
This PR adds some new shared config that sets an environment variable to disable React proptype checking unless in development. Once this is merged and version-bumped, the custom config that does this in m.ag can be removed.

Also did some minor tweaks (space after all `if`s and re-use a variable).
