### PR TITLE
Revert "Fixes Babel presets config"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,7 @@ var config = {
       loader: 'babel-loader',
       exclude: [/node_modules/],
       cacheDirectory: true,
-      query: {
-        presets: ['es2015', 'react']
-      }
+      presets: ['es2015']
     }, { test: /\.coffee$/, loader: 'coffee-loader?sourceMap' }, { include: /\.json$/, loaders: ['json-loader'] }, { test: /\.scss$/,
       loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url!sass?sourceMap') }, { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url') }, { test: /\.hbs$/, loader: 'handlebars-loader' }, imageLoader()]
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.0.8",
   "name": "webpack-config-rentpath",
   "version": "0.0.0-semantically-realeased",
   "description": "Shared webpack config across our apps",

--- a/src/index.js
+++ b/src/index.js
@@ -69,9 +69,7 @@ const config = {
         loader: 'babel-loader',
         exclude: [/node_modules/],
         cacheDirectory: true,
-        query: {
-	  presets: ['es2015', 'react']
-	}
+        presets: ['es2015']
       },
       { test: /\.coffee$/, loader: 'coffee-loader?sourceMap' },
       { include: /\.json$/, loaders: ['json-loader'] },


### PR DESCRIPTION
Reverts rentpath/webpack-config-rentpath#10

We need to revert this and update the commit messages so it can be released.
