### PR TITLE
[NM][#117253529] load svg separately from other images, include hash in name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const cssFilename = function() {
 
 const imageLoader = function() {
   const result = {
-    test: /.*\.(gif|png|jpe?g|svg|ico)$/i
+    test: /.*\.(gif|png|jpe?g|ico)$/i
   }
   if (isDevelopment) {
     result.loader = 'file?name=[name].[ext]'
@@ -79,6 +79,7 @@ const config = {
 	loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url!sass?sourceMap') },
       { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url') },
       { test: /\.hbs$/, loader: 'handlebars-loader' },
+      { test: /\.svg$/, loader: 'file?hash=sha512&digest=hex&name=[name]-[hash].svg' },
       imageLoader()
     ]
   },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/117253529
- include the hash in the name for SVG sprite sheet cache-busting
