### PR TITLE
feat(config): Improve support for svg sprites

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const cssFilename = function() {
 
 const imageLoader = function() {
   const result = {
-    test: /.*\.(gif|png|jpe?g|svg|ico)$/i
+    test: /.*\.(gif|png|jpe?g|ico)$/i
   }
   if (isDevelopment) {
     result.loader = 'file?name=[name].[ext]'
@@ -79,6 +79,7 @@ const config = {
 	loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url!sass?sourceMap') },
       { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap!resolve-url') },
       { test: /\.hbs$/, loader: 'handlebars-loader' },
+      { test: /\.svg$/, loader: 'file?hash=sha512&digest=hex&name=[name]-[hash].svg' },
       imageLoader()
     ]
   },


### PR DESCRIPTION
Implements code from https://github.com/rentpath/webpack-config-rentpath/pull/17, but using semantic release.

Handle .svg files separately from other image files as they will already have been processed by a
sprite generator.  Also use hash in name by default to allow for cache busting for applications that
store sprite in local storage.

Files with .svg extension will include hash in filename in all environments.
