### PR TITLE
[SB][121339069] Use contenthash in css bundle name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const jsFilename = function() {
 }
 
 const cssFilename = function() {
-  return isDevelopment ? '[name]-bundle.css' : '[name]-bundle-[chunkhash].css'
+  return isDevelopment ? '[name]-bundle.css' : '[name]-bundle-[contenthash:20].css'
 }
 
 const imageLoader = function() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/121339069

The chunkhash is just related to the JS chunks. When we used that before this PR, both the JS and CSS bundle files had the same hash, and when there are only CSS changes (without any JS changes) the same chunkhash is computed and reused in the bundle filenames.

With this PR the JS bundle gets one hash and the CSS bundle gets another based on the extracted text content of the CSS. The `:20` limits the length of the hash to 20 chars (same length as `chunkhash`).

Refer to https://github.com/webpack/extract-text-webpack-plugin and search for `contenthash` for more details.
