### PR TITLE
fix(hash): Generate css bundle hash based on content

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const jsFilename = function() {
 }
 
 const cssFilename = function() {
-  return isDevelopment ? '[name]-bundle.css' : '[name]-bundle-[chunkhash].css'
+  return isDevelopment ? '[name]-bundle.css' : '[name]-bundle-[contenthash:20].css'
 }
 
 const imageLoader = function() {


### PR DESCRIPTION
Prior to this change the css bundle hash was the chunkhash which was based on JS only. So when only
CSS changed, the CSS bundle file contents would change, but the filename would not.

https://www.pivotaltracker.com/story/show/121339069

This PR is just to cleanup after I merged my previous PR which got two 👍 but I didn't use commitizen.
