### PR TITLE
[TJ][000000] Removing md5 plugin fixes webpack bundle md5 hashing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,6 @@ const config = {
   },
   amd: { jQuery: true },
   plugins: [
-    new WebpackMd5HashPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),


### PR DESCRIPTION
No Story
- Caching issues on m.ag for wepback led us to removing this plugin. It is not updating the md5 chunkhash on a parent bundle of a modified file.  

NOTE: This is more than likely an issue across the board and is probably an intermittent bug that happens.
